### PR TITLE
chore: añade calendar options

### DIFF
--- a/gatsby-ssr.tsx
+++ b/gatsby-ssr.tsx
@@ -1,0 +1,116 @@
+/* eslint-disable @typescript-eslint/ban-ts-comment, @typescript-eslint/no-empty-function */
+
+import React from 'react';
+
+import { GatsbySSR } from 'gatsby';
+
+global.window = {
+  isSsr: true,
+  localStorage: {
+    // @ts-ignore: Unreachable code error
+    getItem: () => {},
+  },
+  // @ts-ignore: Unreachable code error
+  location: { hostname: '', href: '' },
+  // @ts-ignore: Unreachable code error
+  navigator: {
+    userAgent: '',
+  },
+  // @ts-ignore: Unreachable code error
+  requestAnimationFrame: () => {},
+  // @ts-ignore: Unreachable code error
+  console: {
+    error: () => {},
+  },
+};
+
+global.Element = {
+  // @ts-ignore: Unreachable code error
+  prototype: {},
+};
+
+class Storage {
+  constructor() {}
+}
+
+// @ts-ignore
+global.Storage = Storage;
+
+export const onPreRenderHTML: GatsbySSR['onPreRenderHTML'] = ({
+  getHeadComponents,
+  replaceHeadComponents,
+  getPostBodyComponents,
+  replacePostBodyComponents,
+}) => {
+  const headComponents = getHeadComponents();
+  // Sort components to make <HeadComponents> the first one.
+  headComponents.sort((x, y) => {
+    if (!React.isValidElement(x) || !React.isValidElement(y)) {
+      return 0;
+    }
+
+    if (x?.key === 'HeadComponents') {
+      return -1;
+    }
+    if (y?.key === 'HeadComponents') {
+      return 1;
+    }
+    return 0;
+  });
+  replaceHeadComponents(headComponents);
+
+  const postBodyComponents = getPostBodyComponents();
+
+  postBodyComponents.sort((x, y) => {
+    if (!React.isValidElement(x) || !React.isValidElement(y)) {
+      return 0;
+    }
+
+    if (x?.key === 'PostBodyComponents') {
+      return -1;
+    }
+    if (y?.key === 'PostBodyComponents') {
+      return 1;
+    }
+    return 0;
+  });
+  replacePostBodyComponents(postBodyComponents);
+};
+
+export const onRenderBody: GatsbySSR['onRenderBody'] = ({
+  setHeadComponents,
+  setPreBodyComponents,
+}) => {
+  setHeadComponents([
+    React.createElement(
+      HeadComponents,
+      {
+        key: 'HeadComponents',
+      },
+      null
+    ),
+  ]);
+
+  setPreBodyComponents([]);
+};
+
+export const wrapRootElement: GatsbySSR['wrapRootElement'] = ({ element }) => <>{element}</>;
+
+export const wrapPageElement: GatsbySSR<Record<string, unknown>>['wrapPageElement'] = ({
+  element,
+  props,
+}) => <>{element}</>;
+
+const HeadComponents: React.FC = () => {
+  return (
+    <>
+      <meta charSet="UTF-8" />
+      <meta httpEquiv="x-ua-compatible" content="ie=edge" />
+      <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+      <link rel="shortcut icon" href="/favicon.ico" type="image/vnd.microsoft.icon" />
+
+      <script src="https://apis.google.com/js/api.js" type="text/javascript"></script>
+      <script src="https://accounts.google.com/gsi/client" type="text/javascript"></script>
+    </>
+  );
+};

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "gatsby": "^5.12.4",
     "gatsby-plugin-sass": "^6.12.3",
+    "googleapis": "^129.0.0",
     "gsap": "^3.12.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/pages/components/Calendar.tsx
+++ b/src/pages/components/Calendar.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect } from 'react';
+
+export const Calendar: React.FC = () => {
+  var gapi = window.gapi;
+  var google = window.google;
+
+  var CLIENT_ID = '956204883146-8d1v98lrtuolrmi37nkhe4g5v12t7h13.apps.googleusercontent.com';
+  var API_KEY = 'AIzaSyAMktpLgSt0f0oluEg7iBSoda-gHLNk7ok';
+  var DISCOVERY_DOCS = ['https://www.googleapis.com/discovery/v1/apis/calendar/v3/rest'];
+  var SCOPES = 'https://www.googleapis.com/auth/calendar.events';
+  let tokenClient: any;
+
+  useEffect(() => {
+    gapiLoaded();
+    gisLoaded();
+  }, []);
+
+  function gapiLoaded() {
+    gapi.load('client', async function initializeGapiClient() {
+      await gapi.client.init({
+        apiKey: API_KEY,
+        discoveryDocs: DISCOVERY_DOCS,
+      });
+    });
+  }
+
+  function gisLoaded() {
+    tokenClient = google.accounts.oauth2.initTokenClient({
+      client_id: CLIENT_ID,
+      scope: SCOPES,
+      callback: '',
+    });
+  }
+
+  function handleAuthClick() {
+    tokenClient.callback = async (resp: any) => {
+      if (resp.error !== undefined) {
+        throw resp;
+      }
+      addToCalendar();
+    };
+
+    if (gapi.client.getToken() === null) {
+      tokenClient.requestAccessToken({ prompt: 'consent' });
+    } else {
+      tokenClient.requestAccessToken({ prompt: '' });
+    }
+  }
+
+  function addToCalendar() {
+    const event = {
+      summary: 'Museo Reina Sofía Playground',
+      location: 'Madrid, España',
+      description: 'Probando creación de eventos mediante el Google Calendar API',
+      start: {
+        dateTime: '2023-12-28T09:00:00-07:00',
+        timeZone: 'America/Los_Angeles',
+      },
+      end: {
+        dateTime: '2023-12-28T10:00:00-07:00',
+        timeZone: 'America/Los_Angeles',
+      },
+      recurrence: ['RRULE:FREQ=DAILY;COUNT=2'],
+      attendees: [{ email: 'alvaro.delpazo@biko2.com' }],
+      reminders: {
+        useDefault: false,
+        overrides: [
+          { method: 'email', minutes: 24 * 60 },
+          { method: 'popup', minutes: 10 },
+        ],
+      },
+    };
+
+    const request = gapi.client.calendar.events.insert({
+      calendarId: 'primary',
+      resource: event,
+    });
+
+    request.execute(function (event: any) {
+      document.getElementById('content').innerText = 'Event created: ' + event.htmlLink;
+    });
+  }
+
+  return (
+    <>
+      <button onClick={handleAuthClick}>Añadir evento mediante GoogleCalendarAPI</button>
+
+      <pre id="content" />
+    </>
+  );
+};

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -5,3 +5,15 @@
 .gsap {
   display: inline-block;
 }
+
+.calendar {
+  display: inline-block;
+  padding: 12px;
+  border-radius: 24px;
+  text-decoration: none;
+
+  background-color: aquamarine;
+  color: black;
+  font-weight: 600;
+  font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 
 import gsap from 'gsap';
 
+import { Calendar } from './components/Calendar';
 import * as styles from './index.module.scss';
 
 const Index: React.FC = () => {
@@ -23,6 +24,48 @@ const Index: React.FC = () => {
 
   return (
     <>
+      <Calendar />
+
+      <a
+        target="_blank"
+        className={styles.calendar}
+        href="https://calendar.google.com/calendar/u/0/r/eventedit?text=Reina+Sofia+Playground+Event&dates=20240127T224000Z/20240320T221500Z&details=For+details,+link+here:+http://www.example.com&location=Madrid,+Spain&sf=true&output=xml"
+      >
+        Add to Google calendar link button
+      </a>
+
+      <a
+        target="_blank"
+        className={styles.calendar}
+        href="https://outlook.live.com/calendar/deeplink/compose?path=/calendar/action/compose&rru=addevent&startdt=2024-01-12T16:00:00Z&enddt=2024-01-12T17:40:00Z&subject=Reina+Sofia+Playground+Event&location=Madrid,+Spain"
+      >
+        Add to Outlook calendar link button
+      </a>
+
+      <a
+        target="_blank"
+        className={styles.calendar}
+        href="https://outlook.office.com/calendar/deeplink/compose?path=/calendar/action/compose&rru=addevent&startdt=2024-01-12T16:00:00Z&enddt=2024-01-12T17:40:00Z&subject=Reina+Sofia+Playground+Event&location=Madrid,+Spain"
+      >
+        Add to Office365 calendar link button
+      </a>
+
+      <a
+        target="_blank"
+        className={styles.calendar}
+        href="data:text/calendar;charset=utf8;base64,QkVHSU46VkNBTEVOREFSDQpWRVJTSU9OOjIuMA0KQkVHSU46VkVWRU5UDQpVSUQ6ZmE4NzYzZTdkMmU5ZTkyNmJmMDJlN2RiODcwZGM4YzMNClNVTU1BUlk6QW50ZXMgZGUgQW3DqXJpY2EgZW4gbGEgZ3JhbiBwYW50YWxsYS4gRnVlbnRlcyBvcmlnaW5hcmlhcyB5IG1vZGVybmlkYWQgY2luZW1hdG9ncsOhZmljYSAoSVYpOiBEZXNlYWRhICgxOTUxKSBkZSBSb2JlcnRvIEdhdmFsZMOzbg0KRFRTVEFSVDoyMDI0MDExMlQxNjAwMDBaDQpEVEVORDoyMDI0MDExMlQxNzQwMDBaDQpMT0NBVElPTjpNdXNldSBGdW5kYWNpw7NuIEp1YW4gTWFyY2ggfCBQYWxtYS4gQ2FycmVyIGRlIFNhbnQgTWlxdWVsXCwgMTENCkVORDpWRVZFTlQNCkVORDpWQ0FMRU5EQVI="
+      >
+        Add to Apple calendar link button
+      </a>
+
+      <a
+        target="_blank"
+        className={styles.calendar}
+        href="https://calendar.yahoo.com/?v=60&view=d&type=20&ST=20240112T160000Z&ET=20240112T174000Z&TITLE=Reina+Sofia+Playground+Event&in_loc=Madrid,+Spain"
+      >
+        Add to Yahoo calendar link button
+      </a>
+
       <h1 className={styles.title} id="title">
         Reina Sofía playground
       </h1>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -100,7 +100,8 @@
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
     "skipLibCheck": true /* Skip type checking all .d.ts files. */,
-    "plugins": [{ "name": "typescript-plugin-css-modules" }]
+    "plugins": [{ "name": "typescript-plugin-css-modules" }],
+    "types": ["gapi"]
   },
   "include": ["./src/**/*", "./gatsby-node.ts", "./gatsby-config.ts", "./plugins/**/*"]
 }


### PR DESCRIPTION
Se añade la funcionalidad de añadir eventos a los calendarios personales del usuario. Se han explorado dos posibles opciones:

- Siguiendo un enfoque como en la Fundación March, se permite ir a nuestros calendarios mediante links para añadir las configuraciones requeridas para añadir un evento en cuestión a nuestro calendario. Se han añadido las opciones de Google Calendar, Outlook, Office 365, Apple y Yahoo.

- Probamos la integración de este tipo de eventos a través de las APIs de cada uno de esos servicios, por ahora sólo hemos probado la de GoogleCalendarAPI a la espera de ver qué mecanismo encaja más con las necesidades del Museo. Este enfoque conlleva más trabajo y configuración, pero logra añadir los eventos al calendario a través de un único click, saltándose los pasos de configuración del evento del enfoque anterior.